### PR TITLE
python3/noetic fix

### DIFF
--- a/src/signal_scope/signalScopeSetup.py
+++ b/src/signal_scope/signalScopeSetup.py
@@ -78,7 +78,7 @@ def createSignalFunction(timeLookup, valueLookup):
 
 
 def decodeMessageFunction(messageBytes, messageType):
-    s = str(messageBytes)
+    s = messageBytes.data()
     # Use messageType string to import ros message type
     # TODO: 
     # - find out if is this efficient - e.g. at 500Hz
@@ -87,8 +87,8 @@ def decodeMessageFunction(messageBytes, messageType):
     messagePackage,messageType= str.split(str(messageType),'/')
     exec('from ' + messagePackage + '.msg import ' + messageType )
     exec('p = ' + messageType + '()')
-    p.deserialize(s)
-    return p
+    pp = eval('p.deserialize(s)')
+    return pp
 
 
 msg = LookupHelper()

--- a/src/signal_scope/signalScopeSetup.py
+++ b/src/signal_scope/signalScopeSetup.py
@@ -85,10 +85,12 @@ def decodeMessageFunction(messageBytes, messageType):
     # - cache the imported messages and skip importing those that have been
     # - remove the LCM does for decoding
     messagePackage,messageType= str.split(str(messageType),'/')
-    exec('from ' + messagePackage + '.msg import ' + messageType )
-    exec('p = ' + messageType + '()')
-    pp = eval('p.deserialize(s)')
-    return pp
+    ldict = locals()
+    exec('from ' + messagePackage + '.msg import ' + messageType, ldict)
+    exec('p = ' + messageType + '()', ldict)
+    exec("p.deserialize(s)", ldict)
+    p = ldict['p']
+    return p
 
 
 msg = LookupHelper()


### PR DESCRIPTION
the first change was needed because of this error:
> UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf8 in position 0: invalid start byte
Traceback (most recent call last):
  File "<string>", line 81, in decodeMessageFunction
failed to decode message on topic: /spot/odometry

the second change was needed because the variable p wasnt not available to the main python instance. I dont know what changed.
@heuristicus : in going from python2 to python3 ... did the behaviour of exec() change? Do you happen to know?


(signal scope seems to be working find with noetic now)